### PR TITLE
fix: url for prefix modelldcatno

### DIFF
--- a/testdata/model-catalogTestModellDCAT.ttl
+++ b/testdata/model-catalogTestModellDCAT.ttl
@@ -10,7 +10,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#/> .
+@prefix modelldcatno: <https://data.norge.no/vocabulary/modelldcatno#> .
 
 digdir:PersonOgEnhet  a         modelldcatno:InformationModel , owl:NamedIndividual ;
         modelldcatno:containsModelElement


### PR DESCRIPTION
Etter som jeg leser ut fra https://informasjonsforvaltning.github.io/modelldcat-ap-no/ så blir dette korrekt url