### PR TITLE
Create begrep-skos2-testdataRegSkjema

### DIFF
--- a/testdata/begrep-skos2-testdata
+++ b/testdata/begrep-skos2-testdata
@@ -14,25 +14,78 @@
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix skosno: <https://data.norge.no/vocabulary/skosno#> .
 @prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
-@prefix ns1: <https://data.norge.no/vocabulary/skosno#> .
+@prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 
-<https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepssamling-TestBegrepKSF> a skos:Collection ;
-      dct:identifier "https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepssamling-TestBegrepKSF"^^xsd:anyURI ;
-      skos:member <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepDirekteAngivelseDefinisjon-TestBegrepKSF> , 
-                  <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepDefinisjonViaDefinisjonsobjekt-TestBegrepKSF> ,
-		  <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/BEGREP-886-TestBegrepKSF> ;
-      dct:title "Begrepssamling TestBegrepKSF"@nb ;
-      dcat:contactPoint <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exContactPointBegrepsamling-TestBegrepKSF> ;
+<https://example.com/testdata/exBegrepssamling/begrep-skos2-testdata> a skos:Collection ;
+      dct:identifier "https://example.com/testdata/exBegrepssamling/begrep-skos2-testdata"^^xsd:anyURI ;
+      skos:member <https://example.com/testdata/exbegrep/exBegrepDirekteAngivelseDefinisjon> , 
+                  <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepDefinisjonViaDefinisjonsobjekt-TestBegrepKSF> ;
+      dct:title "Begrepssamling begrep-skos2-testdata"@nb ;
+      dcat:contactPoint <https://example.com/testdata/exBegrepssamling/exContactPointBegrepsamling> ;
       dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/312460726> .
 
-<https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exContactPointBegrepsamling-TestBegrepKSF> a vcard:Organization ;
+<https://example.com/testdata/exBegrepssamling/exContactPointBegrepsamling> a vcard:Organization ;
       vcard:hasEmail <mailto:ansvarligBegrepsamling@test.no> .
 
-<https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepDirekteAngivelseDefinisjon-TestBegrepKSF> a skos:Concept ;
-	    skos:prefLabel "exBegrepDirekteAngivelseDefinisjon - bokmål"@nb ,
-				   "exBegrepDirekteAngivelseDefinisjon - nynorsk"@nn ;
-	    skos:definition "Direkte angivelse av definisjon til begrepet på bokmål"@nb ,
-					"Direkte angivelse av definisjon til omgrepet på nynorsk"@nn ;
-	    dct:identifier "https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepDirekteAngivelseDefinisjon-TestBegrepKSF"^^xsd:anyURI ;
-	    dcat:contactPoint <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exContactPointBegrep-TestBegrepKSF> ;
+<https://example.com/testdata/exbegrep/exBegrepDirekteAngivelseDefinisjon> a skos:Concept ;
+      skos:prefLabel "testbegrep 1"@nb ,
+		     "testomgrep 1"@nn,
+		     "test concept 1"@en ;
+      skos:definition "begrep som kun er ment for test av direkte angivelse av definisjon"@nb ,
+		      "omgrep som berre er meint for test av direkte opplysningar om definisjon"@nn ,
+		      "concept intended only for testing direct statement of definition"@en ;
+      dct:identifier "https://example.com/testdata/exbegrep/exBegrepDirekteAngivelseDefinisjon"^^xsd:anyURI ; 
+      dcat:contactPoint <https://example.com/testdata/exBegrep/exContactPointBegrep> ;
+      dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/312460726> .
+
+
+<https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt> a skos:Concept ;
+      skos:prefLabel "testbegrep 2 - bokmål"@nb ,
+		     "testomgrep 2"@nn ,
+		     "test concept 2"@en ;
+      euvoc:xlDefinition <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/allmenn> ,
+			 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/spesialist> ,
+			 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/utenMaalgruppe> ;
+	    dct:identifier "https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt"^^xsd:anyURI ;
+	    dcat:contactPoint <https://example.com/testdata/exBegrep/exContactPointBegrep> ;
       dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/312460726> .
+
+<https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/allmenn> a euvoc:XlNote ;
+               rdf:value "begrep som kun er ment for test av angivelse av definisjon via definisjonsobjekt - allmenn"@nb ,
+			 "omgrep som berre er meint for test av opplysningar om definisjon via definisjonsobjekt - allmenn"@nn ,
+			 "concept that is only intended for testing the specification of definition via definition object - public"@en ;
+               skosno:relationshipWithSource <https://data.norge.no/vocabulary/relationship-with-source-type#self-composed> ;
+               dct:source [ a rdfs:Resource ;
+			rdfs:label "Definisjon – kilde - egendefinert"@nb ,
+				   "Definisjon – kjelde - eigendefinert"@nn ,
+				   "Definition - source - self composed"@en ;
+			rdfs:seeAlso <https://data.norge.no/specification/skos-ap-no-begrep#Definisjon-kilde> ] ;
+              dct:audience <https://data.norge.no/vocabulary/audience-type#public> .
+
+<https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/spesialist> a euvoc:XlNote ;
+               rdf:value "begrep som kun er ment for test av angivelse av definisjon via definisjonsobjekt - spesialist"@nb ,
+			 "omgrep som berre er meint for test av opplysningar om definisjon via definisjonsobjekt - spesialist"@nn ,
+			 "concept that is only intended for testing the specification of definition via definition object - specialist"@en ;
+               skosno:relationshipWithSource <https://data.norge.no/vocabulary/relationship-with-source-type#derived-from-source> ; 
+               dct:source [ a rdfs:Resource ;
+			rdfs:label "Definisjon – kilde - basert på kilde"@nb ,
+				   "Definisjon – kjelde - basert på kjelde"@nn ,
+				   "Definition - source - derived from source"@en ;
+			rdfs:seeAlso <https://data.norge.no/specification/skos-ap-no-begrep#Definisjon-kilde> ] ;
+              dct:audience <https://data.norge.no/vocabulary/audience-type#specialist> .
+
+<https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/utenMaalgruppe> a euvoc:XlNote ;
+               rdf:value "begrep som kun er ment for test av angivelse av definisjon via definisjonsobjekt - uten målgruppe"@nb ,
+			 "omgrep som berre er meint for test av opplysningar om definisjon via definisjonsobjekt - spesialist"@nn ,
+			 "concept that is only intended for testing the specification of definition via definition object - without audience type"@en ;
+               skosno:relationshipWithSource <https://data.norge.no/vocabulary/relationship-with-source-type#direct-from-source> ;
+               dct:source [ a rdfs:Resource ;
+			rdfs:label "Definisjon – kilde - sitat fra kilde"@nb ,
+				   "Definisjon – kjelde - sitat frå kjelde"@nn ,
+				   "Definition - source - direct from source"@en ;
+			rdfs:seeAlso <https://data.norge.no/specification/skos-ap-no-begrep#Definisjon-kilde> ] .
+
+<https://example.com/testdata/exBegrep/exContactPointBegrep> a vcard:Organization ;
+      vcard:hasEmail <mailto:ansvarligBegrep@test.no> ;
+      vcard:hasOrganizationName "data.norge.no"@nb, "data.norge.no"@nn, "data.norge.no"@en ;
+      vcard:hasTelephone <tel:00000000> .

--- a/testdata/begrep-skos2-testdata
+++ b/testdata/begrep-skos2-testdata
@@ -1,0 +1,38 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosno: <https://data.norge.no/vocabulary/skosno#> .
+@prefix xkos: <http://rdf-vocabulary.ddialliance.org/xkos#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix uneskos: <http://purl.org/umu/uneskos#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix skosno: <https://data.norge.no/vocabulary/skosno#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
+@prefix ns1: <https://data.norge.no/vocabulary/skosno#> .
+
+<https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepssamling-TestBegrepKSF> a skos:Collection ;
+      dct:identifier "https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepssamling-TestBegrepKSF"^^xsd:anyURI ;
+      skos:member <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepDirekteAngivelseDefinisjon-TestBegrepKSF> , 
+                  <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepDefinisjonViaDefinisjonsobjekt-TestBegrepKSF> ,
+		  <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/BEGREP-886-TestBegrepKSF> ;
+      dct:title "Begrepssamling TestBegrepKSF"@nb ;
+      dcat:contactPoint <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exContactPointBegrepsamling-TestBegrepKSF> ;
+      dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/312460726> .
+
+<https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exContactPointBegrepsamling-TestBegrepKSF> a vcard:Organization ;
+      vcard:hasEmail <mailto:ansvarligBegrepsamling@test.no> .
+
+<https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepDirekteAngivelseDefinisjon-TestBegrepKSF> a skos:Concept ;
+	    skos:prefLabel "exBegrepDirekteAngivelseDefinisjon - bokmål"@nb ,
+				   "exBegrepDirekteAngivelseDefinisjon - nynorsk"@nn ;
+	    skos:definition "Direkte angivelse av definisjon til begrepet på bokmål"@nb ,
+					"Direkte angivelse av definisjon til omgrepet på nynorsk"@nn ;
+	    dct:identifier "https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepDirekteAngivelseDefinisjon-TestBegrepKSF"^^xsd:anyURI ;
+	    dcat:contactPoint <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exContactPointBegrep-TestBegrepKSF> ;
+      dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/312460726> .

--- a/testdata/begrep-skos2-testdata
+++ b/testdata/begrep-skos2-testdata
@@ -28,15 +28,18 @@
       vcard:hasEmail <mailto:ansvarligBegrepsamling@test.no> .
 
 <https://example.com/testdata/exbegrep/exBegrepDirekteAngivelseDefinisjon> a skos:Concept ;
+      dct:identifier "https://example.com/testdata/exbegrep/exBegrepDirekteAngivelseDefinisjon"^^xsd:anyURI ; 
+      dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/312460726>
       skos:prefLabel "testbegrep 1"@nb ,
 		     "testomgrep 1"@nn,
 		     "test concept 1"@en ;
       skos:definition "begrep som kun er ment for test av direkte angivelse av definisjon"@nb ,
 		      "omgrep som berre er meint for test av direkte opplysningar om definisjon"@nn ,
 		      "concept intended only for testing direct statement of definition"@en ;
-      dct:identifier "https://example.com/testdata/exbegrep/exBegrepDirekteAngivelseDefinisjon"^^xsd:anyURI ; 
+      dct:subject <https://catalog-admin.staging.fellesdatakatalog.digdir.no/catalogs/312460726/concepts/code-lists/47f92ffc-6173-49da-a614-043d448a3cbf>
+      skosno:valueRange "Verdiområde - kun tekst"@nb ;
       dcat:contactPoint <https://example.com/testdata/exBegrep/exContactPointBegrep> ;
-      dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/312460726> .
+ .
 
 
 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt> a skos:Concept ;
@@ -45,12 +48,12 @@
       skos:prefLabel "testbegrep 2"@nb ,
 		     "testomgrep 2"@nn ,
 		     "test concept 2"@en ;
-      skos:altLabel "tillatt term"@nb ,
-		    "tillaten term"@nn ,
-		    "allowed term"@en ;
-      skos:hiddenLabel "frarådd term"@nb ,
-		       "frårådd term "@nn ,
-		       "not allowed term"@en ;
+      skos:altLabel "tillatt term 1"@nb , "tilltatt term 2"@nb ,
+		    "tillaten term"@nn , "tillaten term 2"@nn ,
+		    "allowed term"@en , "allowed term 2"@en ;
+      skos:hiddenLabel "frarådd term"@nb , "frarådd term 2"@nb ,
+		       "frårådd term"@nn , "frårådd term 2"@nn ,
+		       "not allowed term"@en , "not allowed term 2"@en ;
       euvoc:xlDefinition <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/allmenn> ,
 			 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/spesialist> ,
 			 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/utenMaalgruppe> ;   
@@ -60,8 +63,35 @@
       dct:subject "Fagområde - fritekst"@nb ,
 		  "Fagområde - fritekst - NN"@nn ,
 		  "Subject area - free text"@en ;
-      dcat:contactPoint <https://example.com/testdata/exBegrep/exContactPointBegrep> ;
-       .
+     skos:example "Eksempel - fritekst"@nb ,
+		  "Døme - fritekst"@nn ,
+		  "Example - fritekst"@en ;
+     skosno:valueRange "Verdiområde - tekst"@nb ;
+     skosno:valueRange <https://data.norge.no/specification/skos-ap-no-begrep#Begrep-verdiomr%C3%A5de> ;
+     skosno:isFromConceptIn [a skosno:AssociativeConceptRelation ;
+         skosno:hasToConcept <https://concept-catalog.staging.fellesdatakatalog.digdir.no/collections/312460726/concepts/6bbb74d6-7f89-42de-add6-2d378458286f> ;
+         skosno:relationRole "Relasjonsrolle - bokmål"@nb , "Relasjonsrolle - nynorsk"@nn , "Relationship role"@en ;
+        ] ;
+     skos:hasGenericConceptRelation [a skosno:GenericConceptRelation;
+         skosno:hasGenericConcept <https://concept-catalog.staging.fellesdatakatalog.digdir.no/collections/312460726/concepts/575c79c8-6a77-426f-bfd9-1c75ac7e7bed> ; # har overbegrep
+         dct:description "inndelingskriterium - overbegrep"@nb , "inndelingskriterium - overomgrep"@nn , "classification criterion - general concept"@en ;
+         ];
+      skos:hasGenericConceptRelation [a skosno:GenericConceptRelation; #  har generisk begrepsrelasjon
+         skosno:hasSpecificConcept <https://concept-catalog.staging.fellesdatakatalog.digdir.no/collections/312460726/concepts/0b489b19-4008-4af5-aeb5-58a231e1a5d9> ; # har underbegrep
+         dct:description "inndelingskriterium - underbegrep"@nb , "inndelingskriterium - underomgrep"@nn "classification criterion - sub-term"@en ; # inndelingskriterium
+         ];
+     skosno:hasPartitiveConceptRelation [a skosno:PartitiveConceptRelation; # har partitiv begrepsrelasjon
+         skosno:hasComprehensiveConcept :tstCpt2 ; 
+         dct:description "inndelingskriterium"@nb ; # inndelingskriterium
+         ];
+      skosno:hasPartitiveConceptRelation [a skosno:PartitiveConceptRelation; # har partitiv begrepsrelasjon
+         skosno:hasPartitiveConcept :tstCpt3 ; # har delbegrep
+         dct:description "inndelingskriterium"@nb ; # inndelingskriterium
+         ];
+     dct:isReplacedBy <> ;
+     rdfs:seeAlso <> ;
+     dcat:contactPoint <https://example.com/testdata/exBegrep/exContactPointBegrep> ;
+.
 
 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/allmenn> a euvoc:XlNote ;
                rdf:value "begrep som kun er ment for test av angivelse av definisjon via definisjonsobjekt - allmenn"@nb ,

--- a/testdata/begrep-skos2-testdata
+++ b/testdata/begrep-skos2-testdata
@@ -36,7 +36,7 @@
       skos:definition "begrep som kun er ment for test av direkte angivelse av definisjon"@nb ,
 		      "omgrep som berre er meint for test av direkte opplysningar om definisjon"@nn ,
 		      "concept intended only for testing direct statement of definition"@en ;
-      dct:subject <https://catalog-admin.staging.fellesdatakatalog.digdir.no/catalogs/312460726/concepts/code-lists/47f92ffc-6173-49da-a614-043d448a3cbf>
+      dct:subject <https://catalog-admin-service.staging.fellesdatakatalog.digdir.no/312460726/concepts/code-list/subjects/47f92ffc-6173-49da-a614-043d448a3cbf>
       skosno:valueRange "Verdiområde - kun tekst"@nb ;
       dcat:contactPoint <https://example.com/testdata/exBegrep/exContactPointBegrep> ;
  .

--- a/testdata/begrep-skos2-testdata
+++ b/testdata/begrep-skos2-testdata
@@ -40,15 +40,28 @@
 
 
 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt> a skos:Concept ;
-      skos:prefLabel "testbegrep 2 - bokmål"@nb ,
+      dct:identifier "https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt"^^xsd:anyURI ;
+      dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/312460726> ;
+      skos:prefLabel "testbegrep 2"@nb ,
 		     "testomgrep 2"@nn ,
 		     "test concept 2"@en ;
+      skos:altLabel "tillatt term"@nb ,
+		    "tillaten term"@nn ,
+		    "allowed term"@en ;
+      skos:hiddenLabel "frarådd term"@nb ,
+		       "frårådd term "@nn ,
+		       "not allowed term"@en ;
       euvoc:xlDefinition <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/allmenn> ,
 			 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/spesialist> ,
-			 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/utenMaalgruppe> ;
-	    dct:identifier "https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt"^^xsd:anyURI ;
-	    dcat:contactPoint <https://example.com/testdata/exBegrep/exContactPointBegrep> ;
-      dct:publisher <https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/312460726> .
+			 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/utenMaalgruppe> ;   
+      skos:scopeNote "NB! dette er et fiktivt begrep"@nb ,
+		     "NB! dette er eit fiktivt omgrep"@nn ,
+		     "Note: this is a fictive concept"@en ;
+      dct:subject "Fagområde - fritekst"@nb ,
+		  "Fagområde - fritekst - NN"@nn ,
+		  "Subject area - free text"@en ;
+      dcat:contactPoint <https://example.com/testdata/exBegrep/exContactPointBegrep> ;
+       .
 
 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/allmenn> a euvoc:XlNote ;
                rdf:value "begrep som kun er ment for test av angivelse av definisjon via definisjonsobjekt - allmenn"@nb ,

--- a/testdata/begrep-skos2-testdata
+++ b/testdata/begrep-skos2-testdata
@@ -19,7 +19,7 @@
 <https://example.com/testdata/exBegrepssamling/begrep-skos2-testdata> a skos:Collection ;
       dct:identifier "https://example.com/testdata/exBegrepssamling/begrep-skos2-testdata"^^xsd:anyURI ;
       skos:member <https://example.com/testdata/exbegrep/exBegrepDirekteAngivelseDefinisjon> , 
-                  <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/exBegrepDefinisjonViaDefinisjonsobjekt-TestBegrepKSF> ;
+                  <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt> ;
       dct:title "Begrepssamling begrep-skos2-testdata"@nb ;
       dcat:contactPoint <https://example.com/testdata/exBegrepssamling/exContactPointBegrepsamling> ;
       dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/312460726> .

--- a/testdata/begrep-skos2-testdataRegSkjema
+++ b/testdata/begrep-skos2-testdataRegSkjema
@@ -1,26 +1,19 @@
-@prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
-@prefix org: <http://www.w3.org/ns/org#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix skosno: <https://data.norge.no/vocabulary/skosno#> .
-@prefix xkos: <http://rdf-vocabulary.ddialliance.org/xkos#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix uneskos: <http://purl.org/umu/uneskos#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
-@prefix skosno: <https://data.norge.no/vocabulary/skosno#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
-@prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 
-<https://example.com/testdata/exBegrepssamling/begrep-skos2-testdata> a skos:Collection ;
-      dct:identifier "https://example.com/testdata/exBegrepssamling/begrep-skos2-testdata"^^xsd:anyURI ;
+<https://example.com/testdata/exBegrepssamling/begrep-skos2-testdataRegSkjema> a skos:Collection ;
+      dct:identifier "https://example.com/testdata/exBegrepssamling/begrep-skos2-testdataRegSkjema"^^xsd:anyURI ;
       skos:member <https://example.com/testdata/exbegrep/exBegrepDirekteAngivelseDefinisjon> , 
                   <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt> ;
-      dct:title "Begrepssamling begrep-skos2-testdata"@nb ;
+      dct:title "Begrepssamling begrep-skos2-testdataRegSkjema"@nb ;
       dcat:contactPoint <https://example.com/testdata/exBegrepssamling/exContactPointBegrepsamling> ;
       dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/312460726> .
 
@@ -29,18 +22,20 @@
 
 <https://example.com/testdata/exbegrep/exBegrepDirekteAngivelseDefinisjon> a skos:Concept ;
       dct:identifier "https://example.com/testdata/exbegrep/exBegrepDirekteAngivelseDefinisjon"^^xsd:anyURI ; 
-      dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/312460726>
+      dct:publisher <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/312460726> ;
       skos:prefLabel "testbegrep 1"@nb ,
 		     "testomgrep 1"@nn,
 		     "test concept 1"@en ;
       skos:definition "begrep som kun er ment for test av direkte angivelse av definisjon"@nb ,
 		      "omgrep som berre er meint for test av direkte opplysningar om definisjon"@nn ,
 		      "concept intended only for testing direct statement of definition"@en ;
-      dct:subject <https://catalog-admin-service.staging.fellesdatakatalog.digdir.no/312460726/concepts/code-list/subjects/47f92ffc-6173-49da-a614-043d448a3cbf>
+      dct:subject <https://catalog-admin-service.staging.fellesdatakatalog.digdir.no/312460726/concepts/code-list/subjects/47f92ffc-6173-49da-a614-043d448a3cbf> ;
       skosno:valueRange "Verdiområde - kun tekst"@nb ;
-      dcat:contactPoint <https://example.com/testdata/exBegrep/exContactPointBegrep> ;
- .
-
+      euvoc:status <http://publications.europa.eu/resource/authority/concept-status/CANDIDATE> ;
+      owl:versionInfo "0.9.1" ;
+      euvoc:startDate "2022-01-01"^^xsd:date ;
+      euvoc:endDate "2030-12-31"^^xsd:date ;
+      dcat:contactPoint <https://example.com/testdata/exBegrep/exContactPointBegrep> .
 
 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt> a skos:Concept ;
       dct:identifier "https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt"^^xsd:anyURI ;
@@ -69,29 +64,41 @@
      skosno:valueRange "Verdiområde - tekst"@nb ;
      skosno:valueRange <https://data.norge.no/specification/skos-ap-no-begrep#Begrep-verdiomr%C3%A5de> ;
      skosno:isFromConceptIn [a skosno:AssociativeConceptRelation ;
-         skosno:hasToConcept <https://concept-catalog.staging.fellesdatakatalog.digdir.no/collections/312460726/concepts/6bbb74d6-7f89-42de-add6-2d378458286f> ;
-         skosno:relationRole "Relasjonsrolle - bokmål"@nb , "Relasjonsrolle - nynorsk"@nn , "Relationship role"@en ;
+         skosno:hasToConcept <https://concept-catalog.staging.fellesdatakatalog.digdir.no/collections/312460726/concepts/6bbb74d6-7f89-42de-add6-2d378458286f> ; # har til-begrep
+         skosno:relationRole "Relasjonsrolle - bokmål"@nb , 
+			     "Relasjonsrolle - nynorsk"@nn , 
+			     "Relationship role"@en ;
         ] ;
      skos:hasGenericConceptRelation [a skosno:GenericConceptRelation;
          skosno:hasGenericConcept <https://concept-catalog.staging.fellesdatakatalog.digdir.no/collections/312460726/concepts/575c79c8-6a77-426f-bfd9-1c75ac7e7bed> ; # har overbegrep
-         dct:description "inndelingskriterium - overbegrep"@nb , "inndelingskriterium - overomgrep"@nn , "classification criterion - general concept"@en ;
+         dct:description "inndelingskriterium - overbegrep"@nb , 
+			 "inndelingskriterium - overomgrep"@nn , 
+			 "classification criterion - general concept"@en ;
          ];
       skos:hasGenericConceptRelation [a skosno:GenericConceptRelation; #  har generisk begrepsrelasjon
          skosno:hasSpecificConcept <https://concept-catalog.staging.fellesdatakatalog.digdir.no/collections/312460726/concepts/0b489b19-4008-4af5-aeb5-58a231e1a5d9> ; # har underbegrep
-         dct:description "inndelingskriterium - underbegrep"@nb , "inndelingskriterium - underomgrep"@nn "classification criterion - sub-term"@en ; # inndelingskriterium
+         dct:description "inndelingskriterium - underbegrep"@nb , 
+			 "inndelingskriterium - underomgrep"@nn , 
+			 "classification criterion - sub-concept"@en ;
          ];
      skosno:hasPartitiveConceptRelation [a skosno:PartitiveConceptRelation; # har partitiv begrepsrelasjon
-         skosno:hasComprehensiveConcept :tstCpt2 ; 
-         dct:description "inndelingskriterium"@nb ; # inndelingskriterium
+         skosno:hasComprehensiveConcept <https://concept-catalog.staging.fellesdatakatalog.digdir.no/collections/312460726/concepts/91797c3a-ea30-4ae4-8e82-b3674cbc083e> ; # har helhetsbegrep
+         dct:description "inndelingskriterium - helhetsbegrep"@nb ,
+			 "inndelingskriterium - heilskapsomgrep"@nn , 
+			 "classification criterion - overall concept"@en ;
          ];
       skosno:hasPartitiveConceptRelation [a skosno:PartitiveConceptRelation; # har partitiv begrepsrelasjon
-         skosno:hasPartitiveConcept :tstCpt3 ; # har delbegrep
-         dct:description "inndelingskriterium"@nb ; # inndelingskriterium
+         skosno:hasPartitiveConcept <https://concept-catalog.staging.fellesdatakatalog.digdir.no/collections/312460726/concepts/d7807e93-0ffe-4294-8403-da76781d521b> ; # har delbegrep
+         dct:description "inndelingskriterium - delbegrep"@nb , 
+			 "inndelingskriterium - delomgrep"@nn , 
+			 "classification criterion - part-concept"@en ;
          ];
-     dct:isReplacedBy <> ;
-     rdfs:seeAlso <> ;
-     dcat:contactPoint <https://example.com/testdata/exBegrep/exContactPointBegrep> ;
-.
+     dct:isReplacedBy <https://concept-catalog.staging.fellesdatakatalog.digdir.no/collections/312460726/concepts/862be8a7-b464-4129-8c83-c786dafbd941> ;
+     rdfs:seeAlso <https://concept-catalog.staging.fellesdatakatalog.digdir.no/collections/312460726/concepts/d1dae30e-aff0-4341-8d86-fc3b04279fc1> ;
+     euvoc:status <http://publications.europa.eu/resource/authority/concept-status/DRAFT> ;
+     owl:versionInfo "0.1.0" ;
+     euvoc:startDate "2025-07-01"^^xsd:date ;
+     dcat:contactPoint <https://example.com/testdata/exBegrep/exContactPointBegrep> .
 
 <https://example.com/testdata/exbegrep/exBegrepDefinisjonViaDefinisjonsobjekt/allmenn> a euvoc:XlNote ;
                rdf:value "begrep som kun er ment for test av angivelse av definisjon via definisjonsobjekt - allmenn"@nb ,


### PR DESCRIPTION
Testdata i henhold til skos-ap-no-begrep v2 for å teste importløsningen i begrepsregistreringsløsningen. Dvs. at det kun er tatt med egenskaper som finnes i registreringsskjemaet og som skal kunne importeres.